### PR TITLE
fix: Correct return types in MongoPolicyRepository (Hotfix)

### DIFF
--- a/src/StarGate.Infrastructure/Persistence/MongoPolicyRepository.cs
+++ b/src/StarGate.Infrastructure/Persistence/MongoPolicyRepository.cs
@@ -142,7 +142,7 @@ public class MongoPolicyRepository : IPolicyRepository
     }
 
     /// <inheritdoc />
-    public async Task<List<ProcessTypePolicy>> ListProcessTypePoliciesAsync(
+    public async Task<IReadOnlyList<ProcessTypePolicy>> ListProcessTypePoliciesAsync(
         CancellationToken ct = default)
     {
         var documents = await _processTypePolicies
@@ -153,7 +153,7 @@ public class MongoPolicyRepository : IPolicyRepository
     }
 
     /// <inheritdoc />
-    public async Task<List<ClientPolicyOverride>> ListClientOverridesAsync(
+    public async Task<IReadOnlyList<ClientPolicyOverride>> ListClientOverridesAsync(
         string clientId,
         CancellationToken ct = default)
     {


### PR DESCRIPTION
## 🔥 Hotfix

### Problema
PR #31 è stata mergeata su `main` con errori di compilazione:
- `MongoPolicyRepository` non implementa correttamente `IPolicyRepository`
- Return types errati: `Task<List<T>>` invece di `Task<IReadOnlyList<T>>`

### Errori di Build
```
CS0738: 'MongoPolicyRepository' does not implement interface member
- ListProcessTypePoliciesAsync: wrong return type
- ListClientOverridesAsync: wrong return type
```

### Fix Applicato
Cambiate signature dei metodi:
```csharp
// PRIMA (SBAGLIATO)
public async Task<List<ProcessTypePolicy>> ListProcessTypePoliciesAsync(...)
public async Task<List<ClientPolicyOverride>> ListClientOverridesAsync(...)

// DOPO (CORRETTO)
public async Task<IReadOnlyList<ProcessTypePolicy>> ListProcessTypePoliciesAsync(...)
public async Task<IReadOnlyList<ClientPolicyOverride>> ListClientOverridesAsync(...)
```

### Impatto
- ✅ Build compila correttamente
- ✅ Implementazione corretta dell'interfaccia
- ✅ Nessun breaking change (IReadOnlyList è compatibile con List)

### Dopo il Merge
1. ✅ `main` sarà compilabile
2. ✅ PR #33 (`main` → `develop`) potrà passare i check CI
3. ✅ PR #32 (Unit Tests) potrà fare merge su `develop`

---

**Priorità: URGENTE** - Blocca tutte le altre PR