### PR TITLE
fix: Correct PolicyMapper BackoffStrategy parsing (Hotfix #2)

### DIFF
--- a/src/StarGate.Infrastructure/Persistence/Mappers/PolicyMapper.cs
+++ b/src/StarGate.Infrastructure/Persistence/Mappers/PolicyMapper.cs
@@ -1,7 +1,7 @@
-namespace StarGate.Infrastructure.Persistence.Mappers;
-
 using StarGate.Core.Domain.Configuration;
 using StarGate.Infrastructure.Persistence.Documents;
+
+namespace StarGate.Infrastructure.Persistence.Mappers;
 
 /// <summary>
 /// Maps policy domain entities to/from MongoDB documents.
@@ -105,7 +105,6 @@ public static class PolicyMapper
         {
             "Linear" => BackoffStrategy.Linear,
             "Exponential" => BackoffStrategy.Exponential,
-            "Constant" => BackoffStrategy.Constant,
             _ => throw new ArgumentException($"Unknown backoff strategy: {strategy}", nameof(strategy))
         };
     }


### PR DESCRIPTION
## 🔥 Hotfix #2

### Problema
PR #33 fallisce con errore di compilazione in `PolicyMapper.cs`:
```
CS0117: 'BackoffStrategy' does not contain a definition for 'Constant'
```

### Causa
`BackoffStrategy` enum ha solo 2 valori:
- `Linear`
- `Exponential`

Ma `ParseBackoffStrategy()` include erroneamente un case per `"Constant"` che non esiste.

### Fix Applicato
**PolicyMapper.cs riga 108:**
```csharp
// PRIMA (SBAGLIATO)
private static BackoffStrategy ParseBackoffStrategy(string strategy)
{
    return strategy switch
    {
        "Linear" => BackoffStrategy.Linear,
        "Exponential" => BackoffStrategy.Exponential,
        "Constant" => BackoffStrategy.Constant,  // ❌ NON ESISTE!
        _ => throw new ArgumentException(...)
    };
}

// DOPO (CORRETTO)
private static BackoffStrategy ParseBackoffStrategy(string strategy)
{
    return strategy switch
    {
        "Linear" => BackoffStrategy.Linear,
        "Exponential" => BackoffStrategy.Exponential,
        _ => throw new ArgumentException(...)
    };
}
```

### Bonus Fix
- ✅ Spostati `using` fuori dal namespace (CODING-CONVENTIONS.md)

### Impatto
- ✅ Build compila correttamente
- ✅ Parsing BackoffStrategy funziona con valori validi
- ✅ Mantiene exception per valori sconosciuti

### Dopo il Merge
1. ✅ `main` sarà completamente compilabile
2. ✅ PR #33 (`main` → `develop`) potrà passare CI
3. ✅ PR #32 (Unit Tests) potrà fare merge su `develop`

---

**Priorità: URGENTE** - Blocca PR #33